### PR TITLE
Cannon ammo count

### DIFF
--- a/Assets/Prefabs/Cannon/Cannon.prefab
+++ b/Assets/Prefabs/Cannon/Cannon.prefab
@@ -48,10 +48,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   shootPosition: {fileID: 7293545863962168998}
   prefabToPool: {fileID: 3621945482446078802, guid: 78bf6c873b0bd4d909dbfd1ec215b47a, type: 3}
-  amountToPool: 20
+  amountToPool: 5
   onCannonFire:
     m_PersistentCalls:
       m_Calls: []
+  totalAmmo: 3
 --- !u!114 &1183189936547476379
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Cannon/CannonProjectileController.cs
+++ b/Assets/Scripts/Cannon/CannonProjectileController.cs
@@ -27,10 +27,10 @@ namespace Cannon
             get;
             private set;
         }
-
+        
         private readonly List<ProjectileScript> _pooledProjectiles = new();
         
-        // Start is called before the first frame update
+
         private void Start()
         {
             CreatePooledProjectiles();

--- a/Assets/Scripts/Cannon/CannonProjectileController.cs
+++ b/Assets/Scripts/Cannon/CannonProjectileController.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Attributes;
 using Projectile;
 using UnityEngine.Serialization;
+using TypedUnityEvent;
 
 namespace Cannon
 {
@@ -15,7 +16,7 @@ namespace Cannon
         [Header("Pooling")] 
         [SerializeField, Expandable] private ProjectileScript prefabToPool;
         [SerializeField] private int amountToPool = 20;
-        [SerializeField] private UnityEvent onCannonFire = new();
+        [SerializeField] private GameObjectEvent onCannonFire = new();
 
         [Header("Settings")]
         [Tooltip("The total amount of times the cannon can shoot in the current level")]
@@ -104,7 +105,7 @@ namespace Cannon
                 
                 projectile.Shoot(shootPosition.transform.rotation);
                 
-                onCannonFire.Invoke();
+                onCannonFire.Invoke(projectile.gameObject);
             }
             else
             {

--- a/Assets/Scripts/Cannon/CannonProjectileController.cs
+++ b/Assets/Scripts/Cannon/CannonProjectileController.cs
@@ -16,13 +16,24 @@ namespace Cannon
         [SerializeField, Expandable] private ProjectileScript prefabToPool;
         [SerializeField] private int amountToPool = 20;
         [SerializeField] private UnityEvent onCannonFire = new();
-        
+
+        [Header("Settings")]
+        [Tooltip("The total amount of times the cannon can shoot in the current level")]
+        [SerializeField] private int totalAmmo = 3;
+
+        public int CurrentAmmoCount
+        {
+            get;
+            private set;
+        }
+
         private readonly List<ProjectileScript> _pooledProjectiles = new();
         
         // Start is called before the first frame update
         private void Start()
         {
             CreatePooledProjectiles();
+            CurrentAmmoCount = totalAmmo;
         }
         
         /// <summary>
@@ -76,10 +87,14 @@ namespace Cannon
         }
         
         /// <summary>
-        /// Activates a pooled projectile and invokes the cannon fired event 
+        /// Activates a pooled projectile and invokes the cannon fired event, will not work if the cannon doesn't have ammo
         /// </summary>
         public void ShootProjectile()
         {
+            if (CurrentAmmoCount <= 0)
+                return;
+
+            CurrentAmmoCount--;
             var projectile = GetPooledProjectile();
             
             if (projectile)

--- a/Assets/Scripts/Projectile/ProjectileScript.cs
+++ b/Assets/Scripts/Projectile/ProjectileScript.cs
@@ -107,7 +107,7 @@ namespace Projectile
         
         private void OnCollisionEnter2D(Collision2D collision)
         {
-            EnablesGravity();
+            //EnablesGravity();
             
             var hitScript = collision.gameObject.GetComponent<HitScript>();
             
@@ -116,6 +116,8 @@ namespace Projectile
                 var speed = _rb.velocity.magnitude;
                 hitScript.OnBlockHit(baseDamage * speed);
             }
+
+            ResetAndDeactivate();
         }
         
         /// <summary>

--- a/Assets/Scripts/Projectile/ProjectileScript.cs
+++ b/Assets/Scripts/Projectile/ProjectileScript.cs
@@ -107,7 +107,6 @@ namespace Projectile
         
         private void OnCollisionEnter2D(Collision2D collision)
         {
-            //EnablesGravity();
             
             var hitScript = collision.gameObject.GetComponent<HitScript>();
             


### PR DESCRIPTION
# Pull Request: Cannon ammo count

## Related Issues

- #76 

## Summary of Changes

Added an totalAmmo variable that indicates how many times the cannon can shoot within the level
Changed the onCannonFire event so it also gives a gameobject

## Additional Remarks

There is a public variable for tracking how many projectiles are left

## Pull Criteria

- [x] Code commits have been reviewed
- [ ] Changes have been made if requested